### PR TITLE
chore: change target framework to netstandard1.1

### DIFF
--- a/packages/svg-icons/src-cs/Telerik.SvgIcons/Telerik.SvgIcons.csproj
+++ b/packages/svg-icons/src-cs/Telerik.SvgIcons/Telerik.SvgIcons.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We agreed on using netstandard1.1 to cover all necessary frameworks and avoid multi-targeting.