### PR TITLE
chore: set nuget token

### DIFF
--- a/.github/workflows/nuget_publish.yml
+++ b/.github/workflows/nuget_publish.yml
@@ -20,7 +20,6 @@ jobs:
     env:
       FONT_ICONS: "packages/font-icons/src-cs/Telerik.FontIcons"
       SVG_ICONS: "packages/svg-icons/src-cs/Telerik.SvgIcons"
-      GITHUB_TOKEN: ${{ secrets.NUGET_TOKEN }}
 
     steps:
 
@@ -48,10 +47,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 5.0.x
-          source-url: https://nuget.pkg.github.com/telerik/index.json
-        env:
-          NUGET_AUTH_TOKEN: '%GITHUB_TOKEN%'
-
 
       - name: Build projects
         run: |
@@ -69,6 +64,8 @@ jobs:
           dotnet pack -c Release ${{ env.SVG_ICONS }}/Telerik.SvgIcons.csproj -p:PackageVersion=$VERSION
 
       - name: Push nuget packages
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
         run: |
           dotnet nuget push ${{ env.FONT_ICONS }}/bin/Release/*.nupkg --skip-duplicate
           dotnet nuget push ${{ env.SVG_ICONS }}/bin/Release/*.nupkg --skip-duplicate


### PR DESCRIPTION
Uses new token for publishing on nuget.org

Looks like we need to add dedicated [package README](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/) before publishing. Currently it defaults to the repository README.
