### PR TITLE
chore(ci): change commit message to feat when generating icons metadata

### DIFF
--- a/.github/workflows/build_font.yml
+++ b/.github/workflows/build_font.yml
@@ -52,6 +52,6 @@ jobs:
           echo "Updating font."
 
           git add packages/
-          git commit -m "chore: generate icons metadata"
+          git commit -m "feat: generate icons metadata"
 
           git push


### PR DESCRIPTION
The message is changed to feat instead of chore, so that lerna locates a feat commit inside the packages folder and bumps the version of the package correctly