### PR TITLE
feat: extract styles for svg icons

### DIFF
--- a/packages/font-icons/scss/all.scss
+++ b/packages/font-icons/scss/all.scss
@@ -1,3 +1,3 @@
 @import "index.scss";
 
-@include kendo-icon-styles();
+@include kendo-font-icon-styles();

--- a/packages/font-icons/scss/index.scss
+++ b/packages/font-icons/scss/index.scss
@@ -2,7 +2,7 @@
 @import "_variables.scss";
 @import "_icon-list.scss";
 
-@mixin kendo-icon-styles() {
+@mixin kendo-font-icon-styles() {
 
     // Keep this as a root selector, because it doesn't work when nested inside selector
     @at-root {
@@ -16,7 +16,7 @@
 
 
     // Font icon
-    .k-icon {
+    .k-font-icon {
         width: 1em;
         height: 1em;
         outline: 0;
@@ -45,27 +45,6 @@
         }
     }
 
-
-    // Svg icon
-    .k-svg-icon {
-        width: $ki-icon-size;
-        height: $ki-icon-size;
-        outline: 0;
-        line-height: 1;
-        display: inline-flex;
-        flex-flow: row nowrap;
-        align-items: center;
-        justify-content: center;
-        vertical-align: middle;
-        position: relative;
-
-        > svg {
-            fill: currentColor;
-            flex: 1 1 auto;
-        }
-    }
-
-
     // Empty icon
     .k-i-none::before {
         display: none !important; // stylelint-disable-line
@@ -75,91 +54,37 @@
     // Icon sizes
     .k-icon-xs {
         font-size: $ki-icon-size-xs;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-xs;
-            height: $ki-icon-size-xs;
-        }
     }
     .k-icon-sm {
         font-size: $ki-icon-size-sm;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-sm;
-            height: $ki-icon-size-sm;
-        }
     }
     .k-icon-md {
         font-size: $ki-icon-size-md;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-md;
-            height: $ki-icon-size-md;
-        }
     }
     .k-icon-lg {
         font-size: $ki-icon-size-lg;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-lg;
-            height: $ki-icon-size-lg;
-        }
     }
     .k-icon-xl {
         font-size: $ki-icon-size-xl;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-xl;
-            height: $ki-icon-size-xl;
-        }
     }
     .k-icon-xxl {
         font-size: $ki-icon-size-xxl;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-xxl;
-            height: $ki-icon-size-xxl;
-        }
     }
     .k-icon-xxxl {
         font-size: $ki-icon-size-xxxl;
-
-        &.k-svg-icon {
-            width: $ki-icon-size-xxxl;
-            height: $ki-icon-size-xxxl;
-        }
     }
 
 
     // Flip
-    .k-flip-h,
-    .k-flip-v,
-    .k-flip-h.k-flip-v {
-        &.k-svg-icon {
-            transform: none;
-        }
-    }
     .k-flip-h {
         transform: scaleX( -1 );
-
-        > svg {
-            transform: scaleX( -1 );
-        }
     }
     .k-flip-v {
         transform: scaleY( -1 );
-
-        > svg {
-            transform: scaleY( -1 );
-        }
     }
     .k-flip-h.k-flip-v,
     .k-flip-both {
         transform: scale( -1, -1 );
-
-        > svg {
-            transform: scale( -1, -1 );
-        }
     }
 
 
@@ -167,14 +92,6 @@
     @each $index, $rotate in $ki-rotate-map {
         .k-rotate-#{$index} {
             transform: rotate( #{$rotate} );
-
-            &.k-svg-icon {
-                transform: none;
-            }
-
-            > svg {
-                transform: rotate( #{$rotate} );
-            }
         }
     }
 

--- a/packages/svg-icons/scss/_variables.scss
+++ b/packages/svg-icons/scss/_variables.scss
@@ -1,0 +1,21 @@
+$ki-icon-size: 16px !default;
+
+$ki-icon-size-xs: calc( #{$ki-icon-size} * .75 ) !default;
+$ki-icon-size-sm: calc( #{$ki-icon-size} * .875 ) !default;
+$ki-icon-size-md: $ki-icon-size !default;
+$ki-icon-size-lg: calc( #{$ki-icon-size} * 1.25 ) !default;
+$ki-icon-size-xl: calc( #{$ki-icon-size} * 1.5 ) !default;
+$ki-icon-size-xxl: calc( #{$ki-icon-size} * 2 ) !default;
+$ki-icon-size-xxxl: calc( #{$ki-icon-size} * 3 ) !default;
+
+$ki-rotate-map: (
+    0: 0deg,
+    45: 45deg,
+    90: 90deg,
+    135: 135deg,
+    180: 180deg,
+    225: 225deg,
+    270: 270deg,
+    315: 315deg
+) !default;
+

--- a/packages/svg-icons/scss/all.scss
+++ b/packages/svg-icons/scss/all.scss
@@ -1,0 +1,3 @@
+@import "index.scss";
+
+@include kendo-svg-icon-styles();

--- a/packages/svg-icons/scss/index.scss
+++ b/packages/svg-icons/scss/index.scss
@@ -1,0 +1,95 @@
+@import "_variables.scss";
+
+@mixin kendo-svg-icon-styles() {
+
+    .k-svg-icon {
+        width: $ki-icon-size;
+        height: $ki-icon-size;
+        outline: 0;
+        line-height: 1;
+        display: inline-flex;
+        flex-flow: row nowrap;
+        align-items: center;
+        justify-content: center;
+        vertical-align: middle;
+        position: relative;
+
+        > svg {
+            fill: currentColor;
+            flex: 1 1 auto;
+        }
+    }
+
+    // SVG Icon sizes
+    .k-svg-icon {
+        &.k-icon-xs {
+            width: $ki-icon-size-xs;
+            height: $ki-icon-size-xs;
+        }
+        &.k-icon-sm {
+            width: $ki-icon-size-sm;
+            height: $ki-icon-size-sm;
+        }
+        &.k-icon-md {
+            width: $ki-icon-size-md;
+            height: $ki-icon-size-md;
+        }
+        &.k-icon-lg {
+            width: $ki-icon-size-lg;
+            height: $ki-icon-size-lg;
+        }
+        &.k-icon-xl {
+            width: $ki-icon-size-xl;
+            height: $ki-icon-size-xl;
+        }
+        &.k-icon-xxl {
+            width: $ki-icon-size-xxl;
+            height: $ki-icon-size-xxl;
+        }
+        &.k-icon-xxxl {
+            width: $ki-icon-size-xxxl;
+            height: $ki-icon-size-xxxl;
+        }
+    }
+    
+
+    // Flip
+    .k-flip-h,
+    .k-flip-v,
+    .k-flip-h.k-flip-v {
+        &.k-svg-icon {
+            transform: none;
+        }
+    }
+    .k-flip-h {
+        > svg {
+            transform: scaleX( -1 );
+        }
+    }
+    .k-flip-v {
+        > svg {
+            transform: scaleY( -1 );
+        }
+    }
+    .k-flip-h.k-flip-v,
+    .k-flip-both {
+        > svg {
+            transform: scale( -1, -1 );
+        }
+    }
+
+
+    // Rotate
+    @each $index, $rotate in $ki-rotate-map {
+        .k-rotate-#{$index} {
+            &.k-svg-icon {
+                transform: none;
+            }
+
+            > svg {
+                transform: rotate( #{$rotate} );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
In this PR:

- Extract all styles for SVG icons from the font-icons package;
- Create scss folder for the SVG icons and add the corresponding styles;

Part of https://github.com/telerik/kendo-themes/pull/4666