### PR TITLE
fix: add k-font-icon class to visualize missing icons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,8 +63,8 @@
             iconWrapper.classList.add('icon-wrapper');
 
             const iconElement = document.createElement('span');
-            iconElement.classList.add('k-icon');
-            iconElement.classList.add('k-icon', `k-i-${iconName}`);
+            iconElement.classList.add('k-icon', 'k-font-icon');
+            iconElement.classList.add('k-icon', 'k-font-icon', `k-i-${iconName}`);
 
             const iconLabel = document.createElement('span');
             iconLabel.classList.add('icon-name', 'k-text-center');


### PR DESCRIPTION
Icons from the docs are not correctly rendered.