### PR TITLE
Revert sass if() syntax to restore compatibility

### DIFF
--- a/packages/font-icons/scss/_variables.scss
+++ b/packages/font-icons/scss/_variables.scss
@@ -15,7 +15,7 @@ $ki-icon-size-xxxl: calc( #{$ki-icon-size} * 3 ) !default;
 
 $ki-embed-font: false !default;
 $ki-font-file-url: "kendo-font-icons.ttf" !default;
-$ki-font-url: if(sass($ki-embed-font): $ki-font-data-url; else: $ki-font-file-url) !default;
+$ki-font-url: if( $ki-embed-font == true, $ki-font-data-url, $ki-font-file-url ) !default;
 
 $ki-css-prefix: "k-i-" !default;
 

--- a/packages/font-icons/scss/index.scss
+++ b/packages/font-icons/scss/index.scss
@@ -47,7 +47,7 @@
 
         // SVG Icon sizes
         @each $size, $value in $ki-icon-sizes {
-            #{if(sass($ki-icon-default-size == $size): "&,"; else: null)}
+            #{if($ki-icon-default-size == $size, "&,", null)}
             &.k-icon-#{$size} {
                 font-size: $value;
             }

--- a/packages/svg-icons/scss/index.scss
+++ b/packages/svg-icons/scss/index.scss
@@ -20,7 +20,7 @@
 
         // SVG Icon sizes
         @each $size, $value in $ki-icon-sizes {
-            #{if(sass($ki-icon-default-size == $size): "&,"; else: null)}
+            #{if($ki-icon-default-size == $size, "&,", null)}
             &.k-icon-#{$size} {
                 width: $value;
                 height: $value;


### PR DESCRIPTION
Revert changes to `if()` syntax introduced with https://github.com/telerik/kendo-icons/pull/446