### PR TITLE
Release/v4.x

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -15,9 +15,16 @@ on:
         options:
           - dev
           - stable
+          - hotfix
+      dry-run:
+        description: 'Dry run (skip actual publish and push)'
+        required: false
+        default: false
+        type: boolean
 
 env:
-  TARGET_BRANCH: ${{ github.event.inputs.release-type == 'dev' && 'develop' || 'master' }}
+  TARGET_BRANCH: ${{ github.event.inputs.release-type == 'dev' && 'develop' || github.event.inputs.release-type == 'hotfix' && 'release/v4.x' || 'master' }}
+  DRY_RUN: ${{ github.event.inputs.dry-run == 'true' }}
 
 jobs:
   publish:
@@ -65,7 +72,7 @@ jobs:
           npm ci
 
       - name: Publish dev release
-        if: ${{ github.event.inputs.release-type == 'dev' }}
+        if: ${{ github.event.inputs.release-type == 'dev' && env.DRY_RUN != 'true' }}
         run: |
           npx lerna publish \
             --conventional-commits --conventional-prerelease \
@@ -74,15 +81,23 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
 
+      - name: Dry run dev release
+        if: ${{ github.event.inputs.release-type == 'dev' && env.DRY_RUN == 'true' }}
+        run: |
+          npx lerna version \
+            --conventional-commits --conventional-prerelease \
+            --preid dev --allow-branch develop \
+            --force-publish --exact --yes --no-push
+
       - name: Merge develop to master
-        if: ${{ github.event.inputs.release-type == 'stable' }}
+        if: ${{ github.event.inputs.release-type == 'stable' && github.event.inputs.dry-run != 'true' }}
         run: |
           git fetch --quiet
           git reset --hard origin/master
           git merge --ff-only --quiet origin/develop
 
       - name: Publish stable release
-        if: ${{ github.event.inputs.release-type == 'stable' }}
+        if: ${{ github.event.inputs.release-type == 'stable' && env.DRY_RUN != 'true' }}
         run: |
           npx lerna publish \
             --conventional-commits --conventional-graduate \
@@ -90,8 +105,38 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
 
+      - name: Dry run stable release
+        if: ${{ github.event.inputs.release-type == 'stable' && env.DRY_RUN == 'true' }}
+        run: |
+          npx lerna version \
+            --conventional-commits --conventional-graduate \
+            --force-publish --exact --yes --no-push
+
       - name: Push to GitHub
-        if: ${{ github.event.inputs.release-type == 'stable' }}
+        if: ${{ github.event.inputs.release-type == 'stable' && github.event.inputs.dry-run != 'true' }}
         run: |
           git push origin master --tags --quiet > /dev/null 2>&1
           git push origin master:develop --quiet > /dev/null 2>&1
+
+      - name: Publish hotfix release
+        if: ${{ github.event.inputs.release-type == 'hotfix' && env.DRY_RUN != 'true' }}
+        run: |
+          npx lerna publish \
+            --conventional-commits --conventional-graduate \
+            --create-release github --force-publish --exact \
+            --allow-branch release/v4.x --dist-tag v4-latest
+        env:
+          GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
+
+      - name: Dry run hotfix release
+        if: ${{ github.event.inputs.release-type == 'hotfix' && env.DRY_RUN == 'true' }}
+        run: |
+          npx lerna version \
+            --conventional-commits --conventional-graduate \
+            --allow-branch release/v4.x \
+            --force-publish --exact --yes --no-push
+
+      - name: Push hotfix to GitHub
+        if: ${{ github.event.inputs.release-type == 'hotfix' && github.event.inputs.dry-run != 'true' }}
+        run: |
+          git push origin release/v4.x --tags --quiet > /dev/null 2>&1

--- a/lerna.json
+++ b/lerna.json
@@ -15,7 +15,8 @@
       "loglevel": "silly",
       "allowBranch": [
         "master",
-        "develop"
+        "develop",
+        "release/v4.x"
       ],
       "conventionalCommits": true
     },

--- a/packages/svg-icons/scripts/prepare-svg.js
+++ b/packages/svg-icons/scripts/prepare-svg.js
@@ -4,7 +4,7 @@ const { resolve } = require('path');
 const _ = require('lodash');
 
 const { paths, prepareSvg, buildHast } = require('../../../scripts/shared');
-const { svgTsTemplate, indexTsTemplate } = require('./templates');
+const { svgTsTemplate, indexTsTemplate, aliasTsTemplate } = require('./templates');
 
 // Prepare clean src/icons and dist dirs
 fs.rmSync( 'src/icons', { recursive: true, force: true } );
@@ -77,10 +77,19 @@ function prepareSvgIcons() {
             if ( !iconNames.has( sourceIconName ) ) {
                 throw new Error( `aliases.json: alias "${aliasName}" references unknown icon "${sourceIconName}"` );
             }
+
+            const aliasIconName = aliasName;
+            const aliasTsName = _.camelCase( `${aliasName}-icon` );
+
+            // Generate a separate file for each alias so it doesn't inherit @deprecated from the source
+            const aliasContent = aliasTsTemplate({ aliasIconName, aliasTsName, sourceIconName });
+            fs.writeFileSync( resolve( `src/icons/${aliasIconName}.ts` ), aliasContent );
+
             return {
                 sourceIconName,
+                aliasIconName,
                 sourceTsName: _.camelCase( `${sourceIconName}-icon` ),
-                aliasTsName: _.camelCase( `${aliasName}-icon` )
+                aliasTsName
             };
         });
 

--- a/packages/svg-icons/scripts/templates.js
+++ b/packages/svg-icons/scripts/templates.js
@@ -33,21 +33,14 @@ ${lines.join(',\n')}
 }
 
 function indexTsTemplate( options, aliasReExports ) {
-    const iconExports = options.map(icon => {
-        const exportLine = `export { ${icon.iconTsName} } from './icons/${icon.iconName}';`;
-        if (icon.deprecated) {
-            const reason = icon.deprecated.replacement
-                ? `Use \`${icon.deprecated.replacement}\` instead.`
-                : 'This icon will be removed without a replacement.';
-            return `/** @deprecated since v4. Will be removed in v5. ${reason} */\n${exportLine}`;
-        }
-        return exportLine;
-    }).join('\n');
+    const iconExports = options.map(icon =>
+        `export { ${icon.iconTsName} } from './icons/${icon.iconName}';`
+    ).join('\n');
 
     let aliasExports = '';
     if (aliasReExports && aliasReExports.length) {
         aliasExports = '\n\n// Alias re-exports: unsuffixed names pointing to -outline icons\n// TODO: remove alias with v5\n' +
-            aliasReExports.map(a => `export { ${a.sourceTsName} as ${a.aliasTsName} } from './icons/${a.sourceIconName}';`).join('\n');
+            aliasReExports.map(a => `export { ${a.aliasTsName} } from './icons/${a.aliasIconName}';`).join('\n');
     }
 
     return `export { SVGIcon, SVGIconVariant } from './svg-icon.interface';
@@ -121,7 +114,19 @@ namespace Telerik.SvgIcons
 }
 
 
+function aliasTsTemplate( options ) {
+    const { aliasTsName, sourceIconName } = options;
+
+    return `import { SVGIcon } from '../svg-icon.interface';
+import { ${_.camelCase( `${sourceIconName}-icon` )} } from './${sourceIconName}';
+
+export const ${aliasTsName}: SVGIcon = ${_.camelCase( `${sourceIconName}-icon` )};
+`;
+}
+
+
 module.exports.svgTsTemplate = svgTsTemplate;
 module.exports.indexTsTemplate = indexTsTemplate;
+module.exports.aliasTsTemplate = aliasTsTemplate;
 module.exports.svgCsTemplate = svgCsTemplate;
 module.exports.indexCsTemplate = indexCsTemplate;

--- a/packages/svg-icons/src/icons/arrows-rotate.ts
+++ b/packages/svg-icons/src/icons/arrows-rotate.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { arrowsRotateOutlineIcon } from './arrows-rotate-outline';
+
+export const arrowsRotateIcon: SVGIcon = arrowsRotateOutlineIcon;

--- a/packages/svg-icons/src/icons/award-number.ts
+++ b/packages/svg-icons/src/icons/award-number.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { awardNumberOutlineIcon } from './award-number-outline';
+
+export const awardNumberIcon: SVGIcon = awardNumberOutlineIcon;

--- a/packages/svg-icons/src/icons/award-star.ts
+++ b/packages/svg-icons/src/icons/award-star.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { awardStarOutlineIcon } from './award-star-outline';
+
+export const awardStarIcon: SVGIcon = awardStarOutlineIcon;

--- a/packages/svg-icons/src/icons/award-trophy.ts
+++ b/packages/svg-icons/src/icons/award-trophy.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { awardStarSolidIcon } from './award-star-solid';
+
+export const awardTrophyIcon: SVGIcon = awardStarSolidIcon;

--- a/packages/svg-icons/src/icons/banknote.ts
+++ b/packages/svg-icons/src/icons/banknote.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { banknoteOutlineIcon } from './banknote-outline';
+
+export const banknoteIcon: SVGIcon = banknoteOutlineIcon;

--- a/packages/svg-icons/src/icons/bathtub.ts
+++ b/packages/svg-icons/src/icons/bathtub.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { bathtubeOutlineIcon } from './bathtube-outline';
+
+export const bathtubIcon: SVGIcon = bathtubeOutlineIcon;

--- a/packages/svg-icons/src/icons/bed.ts
+++ b/packages/svg-icons/src/icons/bed.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { bedOutlineIcon } from './bed-outline';
+
+export const bedIcon: SVGIcon = bedOutlineIcon;

--- a/packages/svg-icons/src/icons/bug.ts
+++ b/packages/svg-icons/src/icons/bug.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { bugOutlineIcon } from './bug-outline';
+
+export const bugIcon: SVGIcon = bugOutlineIcon;

--- a/packages/svg-icons/src/icons/buildings.ts
+++ b/packages/svg-icons/src/icons/buildings.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { buildingsOutlineIcon } from './buildings-outline';
+
+export const buildingsIcon: SVGIcon = buildingsOutlineIcon;

--- a/packages/svg-icons/src/icons/clean.ts
+++ b/packages/svg-icons/src/icons/clean.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { cleanOutlineIcon } from './clean-outline';
+
+export const cleanIcon: SVGIcon = cleanOutlineIcon;

--- a/packages/svg-icons/src/icons/dashboard.ts
+++ b/packages/svg-icons/src/icons/dashboard.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { dashboardOutlineIcon } from './dashboard-outline';
+
+export const dashboardIcon: SVGIcon = dashboardOutlineIcon;

--- a/packages/svg-icons/src/icons/devices.ts
+++ b/packages/svg-icons/src/icons/devices.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { devicesOutlineIcon } from './devices-outline';
+
+export const devicesIcon: SVGIcon = devicesOutlineIcon;

--- a/packages/svg-icons/src/icons/discount.ts
+++ b/packages/svg-icons/src/icons/discount.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { discountOutlineIcon } from './discount-outline';
+
+export const discountIcon: SVGIcon = discountOutlineIcon;

--- a/packages/svg-icons/src/icons/doctor.ts
+++ b/packages/svg-icons/src/icons/doctor.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { doctorOutlineIcon } from './doctor-outline';
+
+export const doctorIcon: SVGIcon = doctorOutlineIcon;

--- a/packages/svg-icons/src/icons/education.ts
+++ b/packages/svg-icons/src/icons/education.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { educationOutlineIcon } from './education-outline';
+
+export const educationIcon: SVGIcon = educationOutlineIcon;

--- a/packages/svg-icons/src/icons/eraser.ts
+++ b/packages/svg-icons/src/icons/eraser.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { eraserOutlineIcon } from './eraser-outline';
+
+export const eraserIcon: SVGIcon = eraserOutlineIcon;

--- a/packages/svg-icons/src/icons/file-clock.ts
+++ b/packages/svg-icons/src/icons/file-clock.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { fileClockOutlineIcon } from './file-clock-outline';
+
+export const fileClockIcon: SVGIcon = fileClockOutlineIcon;

--- a/packages/svg-icons/src/icons/filter-sort-asc.ts
+++ b/packages/svg-icons/src/icons/filter-sort-asc.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { filterSortAscSmallIcon } from './filter-sort-asc-small';
+
+export const filterSortAscIcon: SVGIcon = filterSortAscSmallIcon;

--- a/packages/svg-icons/src/icons/filter-sort-desc.ts
+++ b/packages/svg-icons/src/icons/filter-sort-desc.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { filterSortDescSmallIcon } from './filter-sort-desc-small';
+
+export const filterSortDescIcon: SVGIcon = filterSortDescSmallIcon;

--- a/packages/svg-icons/src/icons/food.ts
+++ b/packages/svg-icons/src/icons/food.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { foodOutlineIcon } from './food-outline';
+
+export const foodIcon: SVGIcon = foodOutlineIcon;

--- a/packages/svg-icons/src/icons/lab-technician.ts
+++ b/packages/svg-icons/src/icons/lab-technician.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { labTechnicianOutlineIcon } from './lab-technician-outline';
+
+export const labTechnicianIcon: SVGIcon = labTechnicianOutlineIcon;

--- a/packages/svg-icons/src/icons/laptop.ts
+++ b/packages/svg-icons/src/icons/laptop.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { laptopOutlineIcon } from './laptop-outline';
+
+export const laptopIcon: SVGIcon = laptopOutlineIcon;

--- a/packages/svg-icons/src/icons/lightbulb.ts
+++ b/packages/svg-icons/src/icons/lightbulb.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { lightbulbOutlineIcon } from './lightbulb-outline';
+
+export const lightbulbIcon: SVGIcon = lightbulbOutlineIcon;

--- a/packages/svg-icons/src/icons/luggage.ts
+++ b/packages/svg-icons/src/icons/luggage.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { luggageOutlineIcon } from './luggage-outline';
+
+export const luggageIcon: SVGIcon = luggageOutlineIcon;

--- a/packages/svg-icons/src/icons/microphone.ts
+++ b/packages/svg-icons/src/icons/microphone.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { microphoneOutlineIcon } from './microphone-outline';
+
+export const microphoneIcon: SVGIcon = microphoneOutlineIcon;

--- a/packages/svg-icons/src/icons/mobile-ringing.ts
+++ b/packages/svg-icons/src/icons/mobile-ringing.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { mobileOutlineRingingIcon } from './mobile-outline-ringing';
+
+export const mobileRingingIcon: SVGIcon = mobileOutlineRingingIcon;

--- a/packages/svg-icons/src/icons/mobile.ts
+++ b/packages/svg-icons/src/icons/mobile.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { mobileOutlineIcon } from './mobile-outline';
+
+export const mobileIcon: SVGIcon = mobileOutlineIcon;

--- a/packages/svg-icons/src/icons/non-stop.ts
+++ b/packages/svg-icons/src/icons/non-stop.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { nonStopOutlineIcon } from './non-stop-outline';
+
+export const nonStopIcon: SVGIcon = nonStopOutlineIcon;

--- a/packages/svg-icons/src/icons/nurse.ts
+++ b/packages/svg-icons/src/icons/nurse.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { nurseOutlineIcon } from './nurse-outline';
+
+export const nurseIcon: SVGIcon = nurseOutlineIcon;

--- a/packages/svg-icons/src/icons/patient.ts
+++ b/packages/svg-icons/src/icons/patient.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { patientOutlineIcon } from './patient-outline';
+
+export const patientIcon: SVGIcon = patientOutlineIcon;

--- a/packages/svg-icons/src/icons/pills.ts
+++ b/packages/svg-icons/src/icons/pills.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { pillsOutlineIcon } from './pills-outline';
+
+export const pillsIcon: SVGIcon = pillsOutlineIcon;

--- a/packages/svg-icons/src/icons/pin-bottom.ts
+++ b/packages/svg-icons/src/icons/pin-bottom.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { pinOutlineBottomIcon } from './pin-outline-bottom';
+
+export const pinBottomIcon: SVGIcon = pinOutlineBottomIcon;

--- a/packages/svg-icons/src/icons/pin-top.ts
+++ b/packages/svg-icons/src/icons/pin-top.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { pinOutlineTopIcon } from './pin-outline-top';
+
+export const pinTopIcon: SVGIcon = pinOutlineTopIcon;

--- a/packages/svg-icons/src/icons/plane.ts
+++ b/packages/svg-icons/src/icons/plane.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { planeOutlineIcon } from './plane-outline';
+
+export const planeIcon: SVGIcon = planeOutlineIcon;

--- a/packages/svg-icons/src/icons/recycle.ts
+++ b/packages/svg-icons/src/icons/recycle.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { recycleOutlineIcon } from './recycle-outline';
+
+export const recycleIcon: SVGIcon = recycleOutlineIcon;

--- a/packages/svg-icons/src/icons/ruler-triangle.ts
+++ b/packages/svg-icons/src/icons/ruler-triangle.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { rulerTriangleOutlineIcon } from './ruler-triangle-outline';
+
+export const rulerTriangleIcon: SVGIcon = rulerTriangleOutlineIcon;

--- a/packages/svg-icons/src/icons/ruler.ts
+++ b/packages/svg-icons/src/icons/ruler.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { rulerOutlineAltIcon } from './ruler-outline-alt';
+
+export const rulerIcon: SVGIcon = rulerOutlineAltIcon;

--- a/packages/svg-icons/src/icons/security-check.ts
+++ b/packages/svg-icons/src/icons/security-check.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { securityCheckOutlineIcon } from './security-check-outline';
+
+export const securityCheckIcon: SVGIcon = securityCheckOutlineIcon;

--- a/packages/svg-icons/src/icons/security-lock.ts
+++ b/packages/svg-icons/src/icons/security-lock.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { securityLockOutlineIcon } from './security-lock-outline';
+
+export const securityLockIcon: SVGIcon = securityLockOutlineIcon;

--- a/packages/svg-icons/src/icons/sms.ts
+++ b/packages/svg-icons/src/icons/sms.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { smsOutlineIcon } from './sms-outline';
+
+export const smsIcon: SVGIcon = smsOutlineIcon;

--- a/packages/svg-icons/src/icons/superscript.ts
+++ b/packages/svg-icons/src/icons/superscript.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { supscriptIcon } from './supscript';
+
+export const superscriptIcon: SVGIcon = supscriptIcon;

--- a/packages/svg-icons/src/icons/tablet.ts
+++ b/packages/svg-icons/src/icons/tablet.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { tabletOutlineIcon } from './tablet-outline';
+
+export const tabletIcon: SVGIcon = tabletOutlineIcon;

--- a/packages/svg-icons/src/icons/therapist.ts
+++ b/packages/svg-icons/src/icons/therapist.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { therapistOutlineIcon } from './therapist-outline';
+
+export const therapistIcon: SVGIcon = therapistOutlineIcon;

--- a/packages/svg-icons/src/icons/upgrade.ts
+++ b/packages/svg-icons/src/icons/upgrade.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { upgradeOutlineIcon } from './upgrade-outline';
+
+export const upgradeIcon: SVGIcon = upgradeOutlineIcon;

--- a/packages/svg-icons/src/icons/users.ts
+++ b/packages/svg-icons/src/icons/users.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { usersOutlineIcon } from './users-outline';
+
+export const usersIcon: SVGIcon = usersOutlineIcon;

--- a/packages/svg-icons/src/icons/wallet.ts
+++ b/packages/svg-icons/src/icons/wallet.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { walletOutlineIcon } from './wallet-outline';
+
+export const walletIcon: SVGIcon = walletOutlineIcon;

--- a/packages/svg-icons/src/icons/weight-scale.ts
+++ b/packages/svg-icons/src/icons/weight-scale.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { weightScaleOutlineIcon } from './weight-scale-outline';
+
+export const weightScaleIcon: SVGIcon = weightScaleOutlineIcon;

--- a/packages/svg-icons/src/icons/x-mark.ts
+++ b/packages/svg-icons/src/icons/x-mark.ts
@@ -1,0 +1,4 @@
+import { SVGIcon } from '../svg-icon.interface';
+import { xMarkOutlineIcon } from './x-mark-outline';
+
+export const xMarkIcon: SVGIcon = xMarkOutlineIcon;

--- a/packages/svg-icons/src/index.ts
+++ b/packages/svg-icons/src/index.ts
@@ -86,11 +86,8 @@ export { letterSpaceIcon } from './icons/letter-space';
 export { lineHeightIcon } from './icons/line-height';
 export { listLatinBigIcon } from './icons/list-latin-big';
 export { listLatinSmallIcon } from './icons/list-latin-small';
-/** @deprecated since v4. Will be removed in v5. Use `list-roman-upper` instead. */
 export { listRomanBigIcon } from './icons/list-roman-big';
-/** @deprecated since v4. Will be removed in v5. Use `list-roman-lower` instead. */
 export { listRomanSmallIcon } from './icons/list-roman-small';
-/** @deprecated since v4. Will be removed in v5. Use `list-unordered` instead. */
 export { listUnorderedOutlineIcon } from './icons/list-unordered-outline';
 export { listUnorderedSquareIcon } from './icons/list-unordered-square';
 export { maxHeightIcon } from './icons/max-height';
@@ -115,20 +112,17 @@ export { reportElementIcon } from './icons/report-element';
 export { rightDoubleQuotesIcon } from './icons/right-double-quotes';
 export { wholeWordIcon } from './icons/whole-word';
 export { dataSdsIcon } from './icons/data-sds';
-/** @deprecated since v4. Will be removed in v5. Use `download` instead. */
 export { downloadLightIcon } from './icons/download-light';
 export { eyeSlashIcon } from './icons/eye-slash';
 export { displayInlineBlockIcon } from './icons/display-inline-block';
 export { paperPlaneIcon } from './icons/paper-plane';
 export { gaugeLinearIcon } from './icons/gauge-linear';
 export { gaugeRadialIcon } from './icons/gauge-radial';
-/** @deprecated since v4. Will be removed in v5. Use `envelope` instead. */
 export { envelopeBoxIcon } from './icons/envelope-box';
 export { envelopeLinkIcon } from './icons/envelope-link';
 export { envelopeIcon } from './icons/envelope';
 export { warningCircleIcon } from './icons/warning-circle';
 export { warningTriangleIcon } from './icons/warning-triangle';
-/** @deprecated since v4. Will be removed in v5. Use `info-circle` instead. */
 export { infoSolidIcon } from './icons/info-solid';
 export { fontGrowIcon } from './icons/font-grow';
 export { fontShrinkIcon } from './icons/font-shrink';
@@ -138,24 +132,18 @@ export { textTruncateIcon } from './icons/text-truncate';
 export { textClipIcon } from './icons/text-clip';
 export { borderColorIcon } from './icons/border-color';
 export { borderTypeIcon } from './icons/border-type';
-/** @deprecated since v4. Will be removed in v5. Use `thumb-down` instead. */
 export { thumbDownOutlineIcon } from './icons/thumb-down-outline';
 export { thumbDownIcon } from './icons/thumb-down';
-/** @deprecated since v4. Will be removed in v5. Use `thumb-up` instead. */
 export { thumbUpOutlineIcon } from './icons/thumb-up-outline';
 export { thumbUpIcon } from './icons/thumb-up';
 export { sparklesIcon } from './icons/sparkles';
 export { paragraphMarkIcon } from './icons/paragraph-mark';
 export { paragraphHeightIcon } from './icons/paragraph-height';
-/** @deprecated since v4. Will be removed in v5. Use `user` instead. */
 export { userOutlineIcon } from './icons/user-outline';
-/** @deprecated since v4. Will be removed in v5. Use `wallet` instead. */
 export { walletSolidIcon } from './icons/wallet-solid';
 export { stampIcon } from './icons/stamp';
 export { stickyNoteIcon } from './icons/sticky-note';
-/** @deprecated since v4. Will be removed in v5. Use `ruler` instead. */
 export { rulerOutlineIcon } from './icons/ruler-outline';
-/** @deprecated since v4. Will be removed in v5. Use `eraser` instead. */
 export { eraserOutlineIcon } from './icons/eraser-outline';
 export { editAnnotationsIcon } from './icons/edit-annotations';
 export { highlightIcon } from './icons/highlight';
@@ -166,89 +154,53 @@ export { inputboxIcon } from './icons/inputbox';
 export { scaleIcon } from './icons/scale';
 export { vanIcon } from './icons/van';
 export { truckIcon } from './icons/truck';
-/** @deprecated since v4. Will be removed in v5. Use `wallet` instead. */
 export { walletOutlineIcon } from './icons/wallet-outline';
 export { transactionsIcon } from './icons/transactions';
 export { handleDragDotsIcon } from './icons/handle-drag-dots';
 export { arrowDownLeftIcon } from './icons/arrow-down-left';
-/** @deprecated since v4. Will be removed in v5. Use `recycle` instead. */
 export { recycleSolidIcon } from './icons/recycle-solid';
 export { industrialVehicleIcon } from './icons/industrial-vehicle';
-/** @deprecated since v4. Will be removed in v5. Use `recycle` instead. */
 export { recycleOutlineIcon } from './icons/recycle-outline';
-/** @deprecated since v4. Will be removed in v5. Use `plane` instead. */
 export { planeSolidIcon } from './icons/plane-solid';
-/** @deprecated since v4. Will be removed in v5. Use `plane` instead. */
 export { planeOutlineIcon } from './icons/plane-outline';
 export { moneyExchangeIcon } from './icons/money-exchange';
 export { sustainabilityIcon } from './icons/sustainability';
 export { speedIcon } from './icons/speed';
-/** @deprecated since v4. Will be removed in v5. Use `devices` instead. */
 export { devicesOutlineIcon } from './icons/devices-outline';
-/** @deprecated since v4. Will be removed in v5. Use `devices` instead. */
 export { devicesSolidIcon } from './icons/devices-solid';
-/** @deprecated since v4. Will be removed in v5. Use `instagram` instead. */
 export { instagramBoxIcon } from './icons/instagram-box';
 export { instagramIcon } from './icons/instagram';
-/** @deprecated since v4. Will be removed in v5. Use `laptop` instead. */
 export { laptopOutlineIcon } from './icons/laptop-outline';
-/** @deprecated since v4. Will be removed in v5. Use `laptop` instead. */
 export { laptopSolidIcon } from './icons/laptop-solid';
-/** @deprecated since v4. Will be removed in v5. Use `mobile-ringing` instead. */
 export { mobileOutlineRingingIcon } from './icons/mobile-outline-ringing';
-/** @deprecated since v4. Will be removed in v5. Use `mobile` instead. */
 export { mobileOutlineIcon } from './icons/mobile-outline';
-/** @deprecated since v4. Will be removed in v5. Use `mobile-ringing` instead. */
 export { mobileSolidRingingIcon } from './icons/mobile-solid-ringing';
-/** @deprecated since v4. Will be removed in v5. Use `mobile` instead. */
 export { mobileSolidIcon } from './icons/mobile-solid';
 export { locationsIcon } from './icons/locations';
-/** @deprecated since v4. Will be removed in v5. Use `tablet` instead. */
 export { tabletOutlineIcon } from './icons/tablet-outline';
-/** @deprecated since v4. Will be removed in v5. Use `tablet` instead. */
 export { tabletSolidIcon } from './icons/tablet-solid';
-/** @deprecated since v4. Will be removed in v5. Use `users` instead. */
 export { usersOutlineIcon } from './icons/users-outline';
-/** @deprecated since v4. Will be removed in v5. Use `users` instead. */
 export { usersSolidIcon } from './icons/users-solid';
-/** @deprecated since v4. Will be removed in v5. Use `whatsapp` instead. */
 export { whatsappBoxIcon } from './icons/whatsapp-box';
 export { whatsappIcon } from './icons/whatsapp';
-/** @deprecated since v4. Will be removed in v5. Use `x-logo` instead. */
 export { xLogoBoxIcon } from './icons/x-logo-box';
-/** @deprecated since v4. Will be removed in v5. Use `sms` instead. */
 export { smsOutlineIcon } from './icons/sms-outline';
-/** @deprecated since v4. Will be removed in v5. Use `sms` instead. */
 export { smsSolidIcon } from './icons/sms-solid';
-/** @deprecated since v4. Will be removed in v5. Use `therapist` instead. */
 export { therapistOutlineIcon } from './icons/therapist-outline';
-/** @deprecated since v4. Will be removed in v5. Use `therapist` instead. */
 export { therapistSolidIcon } from './icons/therapist-solid';
-/** @deprecated since v4. Will be removed in v5. Use `patient` instead. */
 export { patientSolidIcon } from './icons/patient-solid';
-/** @deprecated since v4. Will be removed in v5. Use `patient` instead. */
 export { patientOutlineIcon } from './icons/patient-outline';
-/** @deprecated since v4. Will be removed in v5. Use `nurse` instead. */
 export { nurseSolidIcon } from './icons/nurse-solid';
-/** @deprecated since v4. Will be removed in v5. Use `nurse` instead. */
 export { nurseOutlineIcon } from './icons/nurse-outline';
 export { optimizationIcon } from './icons/optimization';
-/** @deprecated since v4. Will be removed in v5. Use `security-check` instead. */
 export { securityCheckOutlineIcon } from './icons/security-check-outline';
-/** @deprecated since v4. Will be removed in v5. Use `security-check` instead. */
 export { securityCheckSolidIcon } from './icons/security-check-solid';
-/** @deprecated since v4. Will be removed in v5. Use `security-lock` instead. */
 export { securityLockOutlineIcon } from './icons/security-lock-outline';
-/** @deprecated since v4. Will be removed in v5. Use `security-lock` instead. */
 export { securityLockSolidIcon } from './icons/security-lock-solid';
-/** @deprecated since v4. Will be removed in v5. Use `upgrade` instead. */
 export { upgradeOutlineIcon } from './icons/upgrade-outline';
 export { upgradeReloadIcon } from './icons/upgrade-reload';
-/** @deprecated since v4. Will be removed in v5. Use `upgrade` instead. */
 export { upgradeSolidIcon } from './icons/upgrade-solid';
-/** @deprecated since v4. Will be removed in v5. Use `food` instead. */
 export { foodSolidIcon } from './icons/food-solid';
-/** @deprecated since v4. Will be removed in v5. Use `food` instead. */
 export { foodOutlineIcon } from './icons/food-outline';
 export { areaIcon } from './icons/area';
 export { arrowShapeIcon } from './icons/arrow-shape';
@@ -260,7 +212,6 @@ export { cubeIcon } from './icons/cube';
 export { distanceIcon } from './icons/distance';
 export { drawFreeIcon } from './icons/draw-free';
 export { dropdownIcon } from './icons/dropdown';
-/** @deprecated since v4. Will be removed in v5. Use `eraser` instead. */
 export { eraserSolidIcon } from './icons/eraser-solid';
 export { hexagonShapeIcon } from './icons/hexagon-shape';
 export { insertFreeTextIcon } from './icons/insert-free-text';
@@ -269,69 +220,40 @@ export { passwordBoxIcon } from './icons/password-box';
 export { perimeterIcon } from './icons/perimeter';
 export { rectangleShapeIcon } from './icons/rectangle-shape';
 export { replaceFreeTextIcon } from './icons/replace-free-text';
-/** @deprecated since v4. Will be removed in v5. Use `ruler` instead. */
 export { rulerOutlineAltIcon } from './icons/ruler-outline-alt';
-/** @deprecated since v4. Will be removed in v5. Use `ruler` instead. */
 export { rulerSolidAltIcon } from './icons/ruler-solid-alt';
-/** @deprecated since v4. Will be removed in v5. Use `ruler` instead. */
 export { rulerSolidIcon } from './icons/ruler-solid';
-/** @deprecated since v4. Will be removed in v5. Use `ruler-triangle` instead. */
 export { rulerTriangleOutlineIcon } from './icons/ruler-triangle-outline';
-/** @deprecated since v4. Will be removed in v5. Use `ruler-triangle` instead. */
 export { rulerTriangleSolidIcon } from './icons/ruler-triangle-solid';
-/** @deprecated since v4. Will be removed in v5. Use `award-number` instead. */
 export { awardNumberOutlineIcon } from './icons/award-number-outline';
-/** @deprecated since v4. Will be removed in v5. Use `award-number` instead. */
 export { awardNumberSolidIcon } from './icons/award-number-solid';
-/** @deprecated since v4. Will be removed in v5. Use `award-trophy` instead. */
 export { awardStarOutlineIcon } from './icons/award-star-outline';
-/** @deprecated since v4. Will be removed in v5. Use `award-trophy` instead. */
 export { awardStarSolidIcon } from './icons/award-star-solid';
-/** @deprecated since v4. Will be removed in v5. Use `banknote` instead. */
 export { banknoteOutlineIcon } from './icons/banknote-outline';
-/** @deprecated since v4. Will be removed in v5. Use `banknote` instead. */
 export { banknoteSolidIcon } from './icons/banknote-solid';
-/** @deprecated since v4. Will be removed in v5. Use `bathtub` instead. */
 export { bathtubeOutlineIcon } from './icons/bathtube-outline';
-/** @deprecated since v4. Will be removed in v5. Use `bathtub` instead. */
 export { bathtubeSolidIcon } from './icons/bathtube-solid';
-/** @deprecated since v4. Will be removed in v5. Use `bed` instead. */
 export { bedOutlineIcon } from './icons/bed-outline';
-/** @deprecated since v4. Will be removed in v5. Use `bed` instead. */
 export { bedSolidIcon } from './icons/bed-solid';
-/** @deprecated since v4. Will be removed in v5. Use `bug` instead. */
 export { bugOutlineIcon } from './icons/bug-outline';
-/** @deprecated since v4. Will be removed in v5. Use `bug` instead. */
 export { bugSolidIcon } from './icons/bug-solid';
-/** @deprecated since v4. Will be removed in v5. Use `buildings` instead. */
 export { buildingsOutlineIcon } from './icons/buildings-outline';
-/** @deprecated since v4. Will be removed in v5. Use `buildings` instead. */
 export { buildingsSolidIcon } from './icons/buildings-solid';
 export { bicycleIcon } from './icons/bicycle';
 export { busIcon } from './icons/bus';
 export { carIcon } from './icons/car';
-/** @deprecated since v4. Will be removed in v5. Use `dashboard` instead. */
 export { dashboardOutlineIcon } from './icons/dashboard-outline';
-/** @deprecated since v4. Will be removed in v5. Use `dashboard` instead. */
 export { dashboardSolidIcon } from './icons/dashboard-solid';
 export { decisionIcon } from './icons/decision';
 export { directionsIcon } from './icons/directions';
-/** @deprecated since v4. Will be removed in v5. Use `education` instead. */
 export { educationOutlineIcon } from './icons/education-outline';
-/** @deprecated since v4. Will be removed in v5. Use `education` instead. */
 export { educationSolidIcon } from './icons/education-solid';
 export { headsetIcon } from './icons/headset';
-/** @deprecated since v4. Will be removed in v5. Use `luggage` instead. */
 export { luggageOutlineIcon } from './icons/luggage-outline';
-/** @deprecated since v4. Will be removed in v5. Use `luggage` instead. */
 export { luggageSolidIcon } from './icons/luggage-solid';
-/** @deprecated since v4. Will be removed in v5. Use `non-stop` instead. */
 export { nonStopOutlineIcon } from './icons/non-stop-outline';
-/** @deprecated since v4. Will be removed in v5. Use `non-stop` instead. */
 export { nonStopSolidIcon } from './icons/non-stop-solid';
-/** @deprecated since v4. Will be removed in v5. Use `pills` instead. */
 export { pillsOutlineIcon } from './icons/pills-outline';
-/** @deprecated since v4. Will be removed in v5. Use `pills` instead. */
 export { pillsSolidIcon } from './icons/pills-solid';
 export { planIcon } from './icons/plan';
 export { undoIcon } from './icons/undo';
@@ -339,9 +261,7 @@ export { redoIcon } from './icons/redo';
 export { arrowRotateCcwIcon } from './icons/arrow-rotate-ccw';
 export { arrowRotateCwIcon } from './icons/arrow-rotate-cw';
 export { arrowsNoRepeatIcon } from './icons/arrows-no-repeat';
-/** @deprecated since v4. Will be removed in v5. Use `arrow-rotate-ccw` instead. */
 export { arrowRotateCcwSmallIcon } from './icons/arrow-rotate-ccw-small';
-/** @deprecated since v4. Will be removed in v5. Use `arrow-rotate-cw` instead. */
 export { arrowRotateCwSmallIcon } from './icons/arrow-rotate-cw-small';
 export { clockIcon } from './icons/clock';
 export { calendarIcon } from './icons/calendar';
@@ -350,7 +270,6 @@ export { printIcon } from './icons/print';
 export { pencilIcon } from './icons/pencil';
 export { trashIcon } from './icons/trash';
 export { paperclipIcon } from './icons/paperclip';
-/** @deprecated since v4. Will be removed in v5. Use `paperclip` instead. */
 export { paperclipAltIcon } from './icons/paperclip-alt';
 export { linkIcon } from './icons/link';
 export { unlinkIcon } from './icons/unlink';
@@ -359,24 +278,18 @@ export { unlinkVerticalIcon } from './icons/unlink-vertical';
 export { lockIcon } from './icons/lock';
 export { unlockIcon } from './icons/unlock';
 export { cancelIcon } from './icons/cancel';
-/** @deprecated since v4. Will be removed in v5. Use `cancel` instead. */
 export { cancelOutlineIcon } from './icons/cancel-outline';
-/** @deprecated since v4. Will be removed in v5. Use `cancel` instead. */
 export { cancelCircleIcon } from './icons/cancel-circle';
 export { checkIcon } from './icons/check';
-/** @deprecated since v4. Will be removed in v5. Use `check` instead. */
 export { checkOutlineIcon } from './icons/check-outline';
 export { checkCircleIcon } from './icons/check-circle';
 export { xIcon } from './icons/x';
-/** @deprecated since v4. Will be removed in v5. Use `x` instead. */
 export { xOutlineIcon } from './icons/x-outline';
 export { xCircleIcon } from './icons/x-circle';
 export { plusIcon } from './icons/plus';
-/** @deprecated since v4. Will be removed in v5. Use `plus` instead. */
 export { plusOutlineIcon } from './icons/plus-outline';
 export { plusCircleIcon } from './icons/plus-circle';
 export { minusIcon } from './icons/minus';
-/** @deprecated since v4. Will be removed in v5. Use `minus` instead. */
 export { minusOutlineIcon } from './icons/minus-outline';
 export { minusCircleIcon } from './icons/minus-circle';
 export { sortAscIcon } from './icons/sort-asc';
@@ -386,11 +299,8 @@ export { sortAscSmallIcon } from './icons/sort-asc-small';
 export { sortDescSmallIcon } from './icons/sort-desc-small';
 export { filterIcon } from './icons/filter';
 export { filterClearIcon } from './icons/filter-clear';
-/** @deprecated since v4. Will be removed in v5. Use `filter` instead. */
 export { filterSmallIcon } from './icons/filter-small';
-/** @deprecated since v4. Will be removed in v5. Use `filter-sort-asc` instead. */
 export { filterSortAscSmallIcon } from './icons/filter-sort-asc-small';
-/** @deprecated since v4. Will be removed in v5. Use `filter-sort-desc` instead. */
 export { filterSortDescSmallIcon } from './icons/filter-sort-desc-small';
 export { filterAddExpressionIcon } from './icons/filter-add-expression';
 export { filterAddGroupIcon } from './icons/filter-add-group';
@@ -399,7 +309,6 @@ export { logoutIcon } from './icons/logout';
 export { downloadIcon } from './icons/download';
 export { uploadIcon } from './icons/upload';
 export { hyperlinkOpenIcon } from './icons/hyperlink-open';
-/** @deprecated since v4. Will be removed in v5. Use `hyperlink-open` instead. */
 export { hyperlinkOpenSmIcon } from './icons/hyperlink-open-sm';
 export { launchIcon } from './icons/launch';
 export { windowIcon } from './icons/window';
@@ -416,9 +325,7 @@ export { arrowsMoveIcon } from './icons/arrows-move';
 export { calculatorIcon } from './icons/calculator';
 export { cartIcon } from './icons/cart';
 export { connectorIcon } from './icons/connector';
-/** @deprecated since v4. Will be removed in v5. Use `plus` instead. */
 export { plusSmIcon } from './icons/plus-sm';
-/** @deprecated since v4. Will be removed in v5. Use `minus` instead. */
 export { minusSmIcon } from './icons/minus-sm';
 export { kpiStatusDenyIcon } from './icons/kpi-status-deny';
 export { kpiStatusHoldIcon } from './icons/kpi-status-hold';
@@ -429,15 +336,12 @@ export { lessOrEqualIcon } from './icons/less-or-equal';
 export { greaterOrEqualIcon } from './icons/greater-or-equal';
 export { divideIcon } from './icons/divide';
 export { accessibilityIcon } from './icons/accessibility';
-/** @deprecated since v4. Will be removed in v5. Use `barcode` instead. */
 export { barcodeOutlineIcon } from './icons/barcode-outline';
 export { barcodeIcon } from './icons/barcode';
 export { barcodeScannerIcon } from './icons/barcode-scanner';
-/** @deprecated since v4. Will be removed in v5. Use `qr-code` instead. */
 export { qrCodeOutlineIcon } from './icons/qr-code-outline';
 export { qrCodeIcon } from './icons/qr-code';
 export { qrCodeScannerIcon } from './icons/qr-code-scanner';
-/** @deprecated since v4. Will be removed in v5. Use `barcode-scanner` instead. */
 export { barcodeQrCodeScannerIcon } from './icons/barcode-qr-code-scanner';
 export { signatureIcon } from './icons/signature';
 export { handIcon } from './icons/hand';
@@ -446,33 +350,20 @@ export { stickIcon } from './icons/stick';
 export { unstickIcon } from './icons/unstick';
 export { setColumnPositionIcon } from './icons/set-column-position';
 export { clockArrowRotateIcon } from './icons/clock-arrow-rotate';
-/** @deprecated since v4. Will be removed in v5. Use `question-circle` instead. */
 export { questionSolidIcon } from './icons/question-solid';
-/** @deprecated since v4. Will be removed in v5. Use `clean` instead. */
 export { cleanOutlineIcon } from './icons/clean-outline';
-/** @deprecated since v4. Will be removed in v5. Use `clean` instead. */
 export { cleanSolidIcon } from './icons/clean-solid';
 export { concreteTruckIcon } from './icons/concrete-truck';
-/** @deprecated since v4. Will be removed in v5. Use `discount` instead. */
 export { discountOutlineIcon } from './icons/discount-outline';
-/** @deprecated since v4. Will be removed in v5. Use `discount` instead. */
 export { discountSolidIcon } from './icons/discount-solid';
-/** @deprecated since v4. Will be removed in v5. Use `doctor` instead. */
 export { doctorOutlineIcon } from './icons/doctor-outline';
-/** @deprecated since v4. Will be removed in v5. Use `doctor` instead. */
 export { doctorSolidIcon } from './icons/doctor-solid';
-/** @deprecated since v4. Will be removed in v5. Use `lab-technician` instead. */
 export { labTechnicianOutlineIcon } from './icons/lab-technician-outline';
-/** @deprecated since v4. Will be removed in v5. Use `lab-technician` instead. */
 export { labTechnicianSolidIcon } from './icons/lab-technician-solid';
 export { sweeperVehicleIcon } from './icons/sweeper-vehicle';
-/** @deprecated since v4. Will be removed in v5. Use `weight-scale` instead. */
 export { weightScaleOutlineIcon } from './icons/weight-scale-outline';
-/** @deprecated since v4. Will be removed in v5. Use `weight-scale` instead. */
 export { weightScaleSolidIcon } from './icons/weight-scale-solid';
-/** @deprecated since v4. Will be removed in v5. Use `microphone` instead. */
 export { microphoneSolidIcon } from './icons/microphone-solid';
-/** @deprecated since v4. Will be removed in v5. Use `microphone` instead. */
 export { microphoneOutlineIcon } from './icons/microphone-outline';
 export { rowExpandIcon } from './icons/row-expand';
 export { rowCollapseIcon } from './icons/row-collapse';
@@ -480,37 +371,21 @@ export { menuFilterIcon } from './icons/menu-filter';
 export { menuSortAscIcon } from './icons/menu-sort-asc';
 export { menuSortDescIcon } from './icons/menu-sort-desc';
 export { pasteSparkleIcon } from './icons/paste-sparkle';
-/** @deprecated since v4. Will be removed in v5. Use `pin` instead. */
 export { pinSolidIcon } from './icons/pin-solid';
-/** @deprecated since v4. Will be removed in v5. Use `pin` instead. */
 export { pinOutlineIcon } from './icons/pin-outline';
-/** @deprecated since v4. Will be removed in v5. Use `unpin` instead. */
 export { unpinSolidIcon } from './icons/unpin-solid';
-/** @deprecated since v4. Will be removed in v5. Use `unpin` instead. */
 export { unpinOutlineIcon } from './icons/unpin-outline';
-/** @deprecated since v4. Will be removed in v5. Use `pin-top` instead. */
 export { pinOutlineTopIcon } from './icons/pin-outline-top';
-/** @deprecated since v4. Will be removed in v5. Use `pin-bottom` instead. */
 export { pinOutlineBottomIcon } from './icons/pin-outline-bottom';
-/** @deprecated since v4. Will be removed in v5. Use `arrow-down` instead. */
 export { arrowDownOutlineIcon } from './icons/arrow-down-outline';
-/** @deprecated since v4. Will be removed in v5. Use `arrow-rotate-cw` instead. */
 export { arrowRotateCwOutlineIcon } from './icons/arrow-rotate-cw-outline';
-/** @deprecated since v4. Will be removed in v5. Use `arrow-up` instead. */
 export { arrowUpOutlineIcon } from './icons/arrow-up-outline';
-/** @deprecated since v4. Will be removed in v5. Use `arrows-rotate` instead. */
 export { arrowsRotateOutlineIcon } from './icons/arrows-rotate-outline';
-/** @deprecated since v4. Will be removed in v5. Use `file-clock` instead. */
 export { fileClockOutlineIcon } from './icons/file-clock-outline';
-/** @deprecated since v4. Will be removed in v5. Use `lightbulb` instead. */
 export { lightbulbOutlineIcon } from './icons/lightbulb-outline';
-/** @deprecated since v4. Will be removed in v5. Use `paperclip` instead. */
 export { paperclipOutlineAltRightIcon } from './icons/paperclip-outline-alt-right';
-/** @deprecated since v4. Will be removed in v5. Use `paperclip` instead. */
 export { paperclipOutlineIcon } from './icons/paperclip-outline';
-/** @deprecated since v4. Will be removed in v5. Use `x-circle` instead. */
 export { xMarkOutlineIcon } from './icons/x-mark-outline';
-/** @deprecated since v4. Will be removed in v5. Use `x-circle` instead. */
 export { xMarkSmOutlineIcon } from './icons/x-mark-sm-outline';
 export { zoomSparkleIcon } from './icons/zoom-sparkle';
 export { playIcon } from './icons/play';
@@ -525,16 +400,11 @@ export { hdIcon } from './icons/hd';
 export { closedCaptionsIcon } from './icons/closed-captions';
 export { playlistIcon } from './icons/playlist';
 export { musicNotesIcon } from './icons/music-notes';
-/** @deprecated since v4. Will be removed in v5. Use `play` instead. */
 export { playSmIcon } from './icons/play-sm';
-/** @deprecated since v4. Will be removed in v5. Use `pause` instead. */
 export { pauseSmIcon } from './icons/pause-sm';
-/** @deprecated since v4. Will be removed in v5. Use `stop` instead. */
 export { stopSmIcon } from './icons/stop-sm';
-/** @deprecated since v4. Will be removed in v5. Use `heart` instead. */
 export { heartOutlineIcon } from './icons/heart-outline';
 export { heartIcon } from './icons/heart';
-/** @deprecated since v4. Will be removed in v5. Use `star` instead. */
 export { starOutlineIcon } from './icons/star-outline';
 export { starIcon } from './icons/star';
 export { checkboxIcon } from './icons/checkbox';
@@ -642,7 +512,6 @@ export { convertLowercaseIcon } from './icons/convert-lowercase';
 export { convertUppercaseIcon } from './icons/convert-uppercase';
 export { strikethroughIcon } from './icons/strikethrough';
 export { subscriptIcon } from './icons/subscript';
-/** @deprecated since v4. Will be removed in v5. Use `superscript` instead. */
 export { supscriptIcon } from './icons/supscript';
 export { divIcon } from './icons/div';
 export { allIcon } from './icons/all';
@@ -667,7 +536,6 @@ export { alignCenterIcon } from './icons/align-center';
 export { alignRightIcon } from './icons/align-right';
 export { alignJustifyIcon } from './icons/align-justify';
 export { alignRemoveIcon } from './icons/align-remove';
-/** @deprecated since v4. Will be removed in v5. Use `text-wrap-arrow` instead. */
 export { textWrapIcon } from './icons/text-wrap';
 export { horizontalRuleIcon } from './icons/horizontal-rule';
 export { tableAlignTopLeftIcon } from './icons/table-align-top-left';
@@ -722,11 +590,9 @@ export { imageMapEditorIcon } from './icons/image-map-editor';
 export { commentIcon } from './icons/comment';
 export { commentRemoveIcon } from './icons/comment-remove';
 export { commentsRemoveIcon } from './icons/comments-remove';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { silverlightIcon } from './icons/silverlight';
 export { mediaManagerIcon } from './icons/media-manager';
 export { videoExternalIcon } from './icons/video-external';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { flashManagerIcon } from './icons/flash-manager';
 export { binocularsIcon } from './icons/binoculars';
 export { copyIcon } from './icons/copy';
@@ -752,7 +618,6 @@ export { puzzlePieceIcon } from './icons/puzzle-piece';
 export { linkAddIcon } from './icons/link-add';
 export { globeLinkIcon } from './icons/globe-link';
 export { globeUnlinkIcon } from './icons/globe-unlink';
-/** @deprecated since v4. Will be removed in v5. Use `envelope-link` instead. */
 export { envelopLinkIcon } from './icons/envelop-link';
 export { anchorIcon } from './icons/anchor';
 export { tableAddIcon } from './icons/table-add';
@@ -799,7 +664,6 @@ export { tableBodyIcon } from './icons/table-body';
 export { tableColumnGroupsIcon } from './icons/table-column-groups';
 export { tableCornerIcon } from './icons/table-corner';
 export { tableRowGroupsIcon } from './icons/table-row-groups';
-/** @deprecated since v4. Will be removed in v5. Use `globe` instead. */
 export { globeOutlineIcon } from './icons/globe-outline';
 export { globeIcon } from './icons/globe';
 export { mapMarkerIcon } from './icons/map-marker';
@@ -809,72 +673,47 @@ export { unpinIcon } from './icons/unpin';
 export { shareIcon } from './icons/share';
 export { userIcon } from './icons/user';
 export { inboxIcon } from './icons/inbox';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { bloggerIcon } from './icons/blogger';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { bloggerBoxIcon } from './icons/blogger-box';
 export { deliciousIcon } from './icons/delicious';
-/** @deprecated since v4. Will be removed in v5. Use `delicious` instead. */
 export { deliciousBoxIcon } from './icons/delicious-box';
 export { diggIcon } from './icons/digg';
-/** @deprecated since v4. Will be removed in v5. Use `digg` instead. */
 export { diggBoxIcon } from './icons/digg-box';
-/** @deprecated since v4. Will be removed in v5. Use `envelope` instead. */
 export { envelopIcon } from './icons/envelop';
-/** @deprecated since v4. Will be removed in v5. Use `envelope` instead. */
 export { envelopBoxIcon } from './icons/envelop-box';
 export { facebookIcon } from './icons/facebook';
-/** @deprecated since v4. Will be removed in v5. Use `facebook` instead. */
 export { facebookBoxIcon } from './icons/facebook-box';
 export { googleIcon } from './icons/google';
-/** @deprecated since v4. Will be removed in v5. Use `google` instead. */
 export { googleBoxIcon } from './icons/google-box';
 export { googlePlusIcon } from './icons/google-plus';
-/** @deprecated since v4. Will be removed in v5. Use `google-plus` instead. */
 export { googlePlusBoxIcon } from './icons/google-plus-box';
 export { linkedinIcon } from './icons/linkedin';
-/** @deprecated since v4. Will be removed in v5. Use `linkedin` instead. */
 export { linkedinBoxIcon } from './icons/linkedin-box';
 export { myspaceIcon } from './icons/myspace';
-/** @deprecated since v4. Will be removed in v5. Use `myspace` instead. */
 export { myspaceBoxIcon } from './icons/myspace-box';
 export { pinterestIcon } from './icons/pinterest';
-/** @deprecated since v4. Will be removed in v5. Use `pinterest` instead. */
 export { pinterestBoxIcon } from './icons/pinterest-box';
 export { redditIcon } from './icons/reddit';
-/** @deprecated since v4. Will be removed in v5. Use `reddit` instead. */
 export { redditBoxIcon } from './icons/reddit-box';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { stumbleUponIcon } from './icons/stumble-upon';
-/** @deprecated since v4. Will be removed in v5. This icon will be removed without a replacement. */
 export { stumbleUponBoxIcon } from './icons/stumble-upon-box';
 export { tellAFriendIcon } from './icons/tell-a-friend';
-/** @deprecated since v4. Will be removed in v5. Use `tell-a-friend` instead. */
 export { tellAFriendBoxIcon } from './icons/tell-a-friend-box';
 export { tumblrIcon } from './icons/tumblr';
-/** @deprecated since v4. Will be removed in v5. Use `tumblr` instead. */
 export { tumblrBoxIcon } from './icons/tumblr-box';
-/** @deprecated since v4. Will be removed in v5. Use `x-logo` instead. */
 export { twitterIcon } from './icons/twitter';
-/** @deprecated since v4. Will be removed in v5. Use `x-logo` instead. */
 export { twitterBoxIcon } from './icons/twitter-box';
 export { yammerIcon } from './icons/yammer';
-/** @deprecated since v4. Will be removed in v5. Use `yammer` instead. */
 export { yammerBoxIcon } from './icons/yammer-box';
 export { behanceIcon } from './icons/behance';
-/** @deprecated since v4. Will be removed in v5. Use `behance` instead. */
 export { behanceBoxIcon } from './icons/behance-box';
 export { dribbbleIcon } from './icons/dribbble';
-/** @deprecated since v4. Will be removed in v5. Use `dribbble` instead. */
 export { dribbbleBoxIcon } from './icons/dribbble-box';
 export { rssIcon } from './icons/rss';
-/** @deprecated since v4. Will be removed in v5. Use `rss` instead. */
 export { rssBoxIcon } from './icons/rss-box';
 export { vimeoIcon } from './icons/vimeo';
-/** @deprecated since v4. Will be removed in v5. Use `vimeo` instead. */
 export { vimeoBoxIcon } from './icons/vimeo-box';
 export { youtubeIcon } from './icons/youtube';
-/** @deprecated since v4. Will be removed in v5. Use `youtube` instead. */
 export { youtubeBoxIcon } from './icons/youtube-box';
 export { folderIcon } from './icons/folder';
 export { folderOpenIcon } from './icons/folder-open';
@@ -892,7 +731,6 @@ export { fileMdbIcon } from './icons/file-mdb';
 export { filePptIcon } from './icons/file-ppt';
 export { filePdfIcon } from './icons/file-pdf';
 export { filePsdIcon } from './icons/file-psd';
-/** @deprecated since v4. Will be removed in v5. Use `file` instead. */
 export { fileFlashIcon } from './icons/file-flash';
 export { fileConfigIcon } from './icons/file-config';
 export { fileAscxIcon } from './icons/file-ascx';
@@ -987,58 +825,57 @@ export { chartCandlestickIcon } from './icons/chart-candlestick';
 export { chartOhlcIcon } from './icons/chart-ohlc';
 export { chartRadarIcon } from './icons/chart-radar';
 export { chartRadarMarkersIcon } from './icons/chart-radar-markers';
-/** @deprecated since v4. Will be removed in v5. Use `chart-radar` instead. */
 export { chartRadarFilledIcon } from './icons/chart-radar-filled';
 export { chartRoseIcon } from './icons/chart-rose';
 export { chartChoroplethIcon } from './icons/chart-choropleth';
 
 // Alias re-exports: unsuffixed names pointing to -outline icons
 // TODO: remove alias with v5
-export { arrowsRotateOutlineIcon as arrowsRotateIcon } from './icons/arrows-rotate-outline';
-export { awardNumberOutlineIcon as awardNumberIcon } from './icons/award-number-outline';
-export { awardStarOutlineIcon as awardStarIcon } from './icons/award-star-outline';
-export { awardStarSolidIcon as awardTrophyIcon } from './icons/award-star-solid';
-export { banknoteOutlineIcon as banknoteIcon } from './icons/banknote-outline';
-export { bedOutlineIcon as bedIcon } from './icons/bed-outline';
-export { bugOutlineIcon as bugIcon } from './icons/bug-outline';
-export { buildingsOutlineIcon as buildingsIcon } from './icons/buildings-outline';
-export { cleanOutlineIcon as cleanIcon } from './icons/clean-outline';
-export { dashboardOutlineIcon as dashboardIcon } from './icons/dashboard-outline';
-export { devicesOutlineIcon as devicesIcon } from './icons/devices-outline';
-export { discountOutlineIcon as discountIcon } from './icons/discount-outline';
-export { doctorOutlineIcon as doctorIcon } from './icons/doctor-outline';
-export { educationOutlineIcon as educationIcon } from './icons/education-outline';
-export { eraserOutlineIcon as eraserIcon } from './icons/eraser-outline';
-export { fileClockOutlineIcon as fileClockIcon } from './icons/file-clock-outline';
-export { foodOutlineIcon as foodIcon } from './icons/food-outline';
-export { labTechnicianOutlineIcon as labTechnicianIcon } from './icons/lab-technician-outline';
-export { laptopOutlineIcon as laptopIcon } from './icons/laptop-outline';
-export { lightbulbOutlineIcon as lightbulbIcon } from './icons/lightbulb-outline';
-export { luggageOutlineIcon as luggageIcon } from './icons/luggage-outline';
-export { microphoneOutlineIcon as microphoneIcon } from './icons/microphone-outline';
-export { mobileOutlineIcon as mobileIcon } from './icons/mobile-outline';
-export { nonStopOutlineIcon as nonStopIcon } from './icons/non-stop-outline';
-export { nurseOutlineIcon as nurseIcon } from './icons/nurse-outline';
-export { patientOutlineIcon as patientIcon } from './icons/patient-outline';
-export { pillsOutlineIcon as pillsIcon } from './icons/pills-outline';
-export { pinOutlineBottomIcon as pinBottomIcon } from './icons/pin-outline-bottom';
-export { pinOutlineTopIcon as pinTopIcon } from './icons/pin-outline-top';
-export { planeOutlineIcon as planeIcon } from './icons/plane-outline';
-export { recycleOutlineIcon as recycleIcon } from './icons/recycle-outline';
-export { rulerOutlineAltIcon as rulerIcon } from './icons/ruler-outline-alt';
-export { rulerTriangleOutlineIcon as rulerTriangleIcon } from './icons/ruler-triangle-outline';
-export { securityCheckOutlineIcon as securityCheckIcon } from './icons/security-check-outline';
-export { securityLockOutlineIcon as securityLockIcon } from './icons/security-lock-outline';
-export { smsOutlineIcon as smsIcon } from './icons/sms-outline';
-export { tabletOutlineIcon as tabletIcon } from './icons/tablet-outline';
-export { therapistOutlineIcon as therapistIcon } from './icons/therapist-outline';
-export { upgradeOutlineIcon as upgradeIcon } from './icons/upgrade-outline';
-export { usersOutlineIcon as usersIcon } from './icons/users-outline';
-export { walletOutlineIcon as walletIcon } from './icons/wallet-outline';
-export { weightScaleOutlineIcon as weightScaleIcon } from './icons/weight-scale-outline';
-export { xMarkOutlineIcon as xMarkIcon } from './icons/x-mark-outline';
-export { mobileOutlineRingingIcon as mobileRingingIcon } from './icons/mobile-outline-ringing';
-export { bathtubeOutlineIcon as bathtubIcon } from './icons/bathtube-outline';
-export { filterSortAscSmallIcon as filterSortAscIcon } from './icons/filter-sort-asc-small';
-export { filterSortDescSmallIcon as filterSortDescIcon } from './icons/filter-sort-desc-small';
-export { supscriptIcon as superscriptIcon } from './icons/supscript';
+export { arrowsRotateIcon } from './icons/arrows-rotate';
+export { awardNumberIcon } from './icons/award-number';
+export { awardStarIcon } from './icons/award-star';
+export { awardTrophyIcon } from './icons/award-trophy';
+export { banknoteIcon } from './icons/banknote';
+export { bedIcon } from './icons/bed';
+export { bugIcon } from './icons/bug';
+export { buildingsIcon } from './icons/buildings';
+export { cleanIcon } from './icons/clean';
+export { dashboardIcon } from './icons/dashboard';
+export { devicesIcon } from './icons/devices';
+export { discountIcon } from './icons/discount';
+export { doctorIcon } from './icons/doctor';
+export { educationIcon } from './icons/education';
+export { eraserIcon } from './icons/eraser';
+export { fileClockIcon } from './icons/file-clock';
+export { foodIcon } from './icons/food';
+export { labTechnicianIcon } from './icons/lab-technician';
+export { laptopIcon } from './icons/laptop';
+export { lightbulbIcon } from './icons/lightbulb';
+export { luggageIcon } from './icons/luggage';
+export { microphoneIcon } from './icons/microphone';
+export { mobileIcon } from './icons/mobile';
+export { nonStopIcon } from './icons/non-stop';
+export { nurseIcon } from './icons/nurse';
+export { patientIcon } from './icons/patient';
+export { pillsIcon } from './icons/pills';
+export { pinBottomIcon } from './icons/pin-bottom';
+export { pinTopIcon } from './icons/pin-top';
+export { planeIcon } from './icons/plane';
+export { recycleIcon } from './icons/recycle';
+export { rulerIcon } from './icons/ruler';
+export { rulerTriangleIcon } from './icons/ruler-triangle';
+export { securityCheckIcon } from './icons/security-check';
+export { securityLockIcon } from './icons/security-lock';
+export { smsIcon } from './icons/sms';
+export { tabletIcon } from './icons/tablet';
+export { therapistIcon } from './icons/therapist';
+export { upgradeIcon } from './icons/upgrade';
+export { usersIcon } from './icons/users';
+export { walletIcon } from './icons/wallet';
+export { weightScaleIcon } from './icons/weight-scale';
+export { xMarkIcon } from './icons/x-mark';
+export { mobileRingingIcon } from './icons/mobile-ringing';
+export { bathtubIcon } from './icons/bathtub';
+export { filterSortAscIcon } from './icons/filter-sort-asc';
+export { filterSortDescIcon } from './icons/filter-sort-desc';
+export { superscriptIcon } from './icons/superscript';


### PR DESCRIPTION
we will try to release this manually.

It handles aliases, even if they result in the same icon underneath.
<img width="693" height="81" alt="image" src="https://github.com/user-attachments/assets/f49e08b9-3601-4442-9c7d-d4a019303764" />

covers for:
<img width="569" height="90" alt="image" src="https://github.com/user-attachments/assets/fd67df8c-85de-40b8-a3a6-6e1e6e86ce8e" />
