### PR TITLE
fix(SvgIcon): check cast result in SvgIconBase.Equals instead of original obj

### DIFF
--- a/packages/svg-icons/src-cs/Telerik.SvgIcons/Models/SvgIconBase.cs
+++ b/packages/svg-icons/src-cs/Telerik.SvgIcons/Models/SvgIconBase.cs
@@ -16,7 +16,7 @@ namespace Telerik.SvgIcons
         {
             var other = obj as SvgIconBase;
 
-            if (obj == null)
+            if (other == null)
             {
                 return false;
             }


### PR DESCRIPTION
## Problem

SvgIconBase.Equals checks \obj != null\ instead of \other != null\ after the \s\ cast. When a non-\SvgIconBase\ type (e.g. a \string\) is passed, the cast result \other\ is \
ull\ but \obj\ is not, so the null guard is bypassed and \other.Name\ throws a \NullReferenceException\.

## Fix

Change \if (obj == null)\ to \if (other == null)\ on line 19.