### PR TITLE
chore: add .npmrc with HAR registry and override for publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -73,6 +73,7 @@ jobs:
             --allow-branch develop --force-publish --exact --yes
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: Merge develop to master
         if: ${{ github.event.inputs.release-type == 'stable' }}
@@ -89,6 +90,7 @@ jobs:
             --create-release github --force-publish --exact
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: Push to GitHub
         if: ${{ github.event.inputs.release-type == 'stable' }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/
+min-release-age=14

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/


### PR DESCRIPTION
Add `.npmrc` with the HAR registry so that Dependabot resolves packages through the same registry as CI. Override the registry back to npmjs.org at publish time via `NPM_CONFIG_REGISTRY` env var.

Same approach as [kendo-themes](https://github.com/telerik/kendo-themes/commit/10f6bfa1b84fa36c3d150122b10c92a68d7ec336).

Ref: telerik/kendo-themes-private#601