### PR TITLE
chore(ci): run npm ci after merge for stable releases

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -60,6 +60,13 @@ jobs:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Merge develop to master
+        if: ${{ github.event.inputs.release-type == 'stable' }}
+        run: |
+          git fetch --quiet
+          git reset --hard origin/master
+          git merge --ff-only --quiet origin/develop
+
       - name: Install
         run: |
           npm ci
@@ -74,13 +81,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-
-      - name: Merge develop to master
-        if: ${{ github.event.inputs.release-type == 'stable' }}
-        run: |
-          git fetch --quiet
-          git reset --hard origin/master
-          git merge --ff-only --quiet origin/develop
 
       - name: Publish stable release
         if: ${{ github.event.inputs.release-type == 'stable' }}


### PR DESCRIPTION
Move the install step after the merge-develop-to-master step so that node_modules matches the final working tree. Previously, npm ci ran against master's lockfile before the merge, which could leave native optional dependencies (like @resvg/resvg-js) unresolved when the merged code needed them.