### PR TITLE
fix: revert runtime customization CSS variables support

### DIFF
--- a/packages/font-icons/scss/_variables.scss
+++ b/packages/font-icons/scss/_variables.scss
@@ -5,13 +5,13 @@ $ki-icon-default-size: md !default;
 $ki-font-family: "WebComponentsIcons" !default;
 $ki-icon-size: 16px !default;
 
-$ki-icon-size-xs: var(--kendo-icon-size-xs, calc( var(--kendo-icon-size, #{$ki-icon-size}) * .75 )) !default;
-$ki-icon-size-sm: var(--kendo-icon-size-sm, calc( var(--kendo-icon-size, #{$ki-icon-size}) * .875 )) !default;
-$ki-icon-size-md: var(--kendo-icon-size-md, var(--kendo-icon-size, #{$ki-icon-size})) !default;
-$ki-icon-size-lg: var(--kendo-icon-size-lg, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 1.25 )) !default;
-$ki-icon-size-xl: var(--kendo-icon-size-xl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 1.5 )) !default;
-$ki-icon-size-xxl: var(--kendo-icon-size-xxl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 2 )) !default;
-$ki-icon-size-xxxl: var(--kendo-icon-size-xxxl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 3 )) !default;
+$ki-icon-size-xs: calc( #{$ki-icon-size} * .75 ) !default;
+$ki-icon-size-sm: calc( #{$ki-icon-size} * .875 ) !default;
+$ki-icon-size-md: $ki-icon-size !default;
+$ki-icon-size-lg: calc( #{$ki-icon-size} * 1.25 ) !default;
+$ki-icon-size-xl: calc( #{$ki-icon-size} * 1.5 ) !default;
+$ki-icon-size-xxl: calc( #{$ki-icon-size} * 2 ) !default;
+$ki-icon-size-xxxl: calc( #{$ki-icon-size} * 3 ) !default;
 
 $ki-embed-font: false !default;
 $ki-font-file-url: "kendo-font-icons.ttf" !default;

--- a/packages/font-icons/scss/index.scss
+++ b/packages/font-icons/scss/index.scss
@@ -16,17 +16,6 @@
         }
     }
 
-    :root {
-        --kendo-icon-size: #{$ki-icon-size};
-        --kendo-icon-size-xs: calc( var(--kendo-icon-size) * .75 );
-        --kendo-icon-size-sm: calc( var(--kendo-icon-size) * .875 );
-        --kendo-icon-size-md: var(--kendo-icon-size);
-        --kendo-icon-size-lg: calc( var(--kendo-icon-size) * 1.25 );
-        --kendo-icon-size-xl: calc( var(--kendo-icon-size) * 1.5 );
-        --kendo-icon-size-xxl: calc( var(--kendo-icon-size) * 2 );
-        --kendo-icon-size-xxxl: calc( var(--kendo-icon-size) * 3 );
-        --kendo-icon-rotation: 0deg;
-    }
 
     // Font icon
     .k-font-icon {
@@ -50,14 +39,13 @@
         position: relative;
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
-        transform: rotate( var(--kendo-icon-rotation) );
 
         &:hover,
         &:focus {
             text-decoration: none;
         }
 
-        // Font Icon sizes
+        // SVG Icon sizes
         @each $size, $value in $ki-icon-sizes {
             #{if($ki-icon-default-size == $size, "&,", null)}
             &.k-icon-#{$size} {
@@ -87,8 +75,7 @@
     // Rotate
     @each $index, $rotate in $ki-rotate-map {
         .k-rotate-#{$index} {
-            --kendo-icon-rotation: #{$rotate};
-            transform: rotate( var(--kendo-icon-rotation) );
+            transform: rotate( #{$rotate} );
         }
     }
 

--- a/packages/svg-icons/scss/_variables.scss
+++ b/packages/svg-icons/scss/_variables.scss
@@ -2,15 +2,13 @@ $ki-icon-default-size: md !default;
 
 $ki-icon-size: 16px !default;
 
-$ki-icon-size-xs: var(--kendo-icon-size-xs, calc( var(--kendo-icon-size, #{$ki-icon-size}) * .75 )) !default;
-$ki-icon-size-sm: var(--kendo-icon-size-sm, calc( var(--kendo-icon-size, #{$ki-icon-size}) * .875 )) !default;
-$ki-icon-size-md: var(--kendo-icon-size-md, var(--kendo-icon-size, #{$ki-icon-size})) !default;
-$ki-icon-size-lg: var(--kendo-icon-size-lg, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 1.25 )) !default;
-$ki-icon-size-xl: var(--kendo-icon-size-xl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 1.5 )) !default;
-$ki-icon-size-xxl: var(--kendo-icon-size-xxl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 2 )) !default;
-$ki-icon-size-xxxl: var(--kendo-icon-size-xxxl, calc( var(--kendo-icon-size, #{$ki-icon-size}) * 3 )) !default;
-
-$ki-icon-stroke-width: 1.5 !default;
+$ki-icon-size-xs: calc( #{$ki-icon-size} * .75 ) !default;
+$ki-icon-size-sm: calc( #{$ki-icon-size} * .875 ) !default;
+$ki-icon-size-md: $ki-icon-size !default;
+$ki-icon-size-lg: calc( #{$ki-icon-size} * 1.25 ) !default;
+$ki-icon-size-xl: calc( #{$ki-icon-size} * 1.5 ) !default;
+$ki-icon-size-xxl: calc( #{$ki-icon-size} * 2 ) !default;
+$ki-icon-size-xxxl: calc( #{$ki-icon-size} * 3 ) !default;
 
 $ki-icon-sizes: (
     xs: $ki-icon-size-xs,

--- a/packages/svg-icons/scss/index.scss
+++ b/packages/svg-icons/scss/index.scss
@@ -3,20 +3,6 @@
 
 @mixin kendo-svg-icon-styles() {
 
-    :root {
-        --kendo-icon-size: #{$ki-icon-size};
-        --kendo-icon-size-xs: calc( var(--kendo-icon-size) * .75 );
-        --kendo-icon-size-sm: calc( var(--kendo-icon-size) * .875 );
-        --kendo-icon-size-md: var(--kendo-icon-size);
-        --kendo-icon-size-lg: calc( var(--kendo-icon-size) * 1.25 );
-        --kendo-icon-size-xl: calc( var(--kendo-icon-size) * 1.5 );
-        --kendo-icon-size-xxl: calc( var(--kendo-icon-size) * 2 );
-        --kendo-icon-size-xxxl: calc( var(--kendo-icon-size) * 3 );
-        --kendo-icon-stroke-width: #{$ki-icon-stroke-width};
-        --kendo-icon-rotation: 0deg;
-        --kendo-icon-color: currentColor;
-    }
-
     .k-svg-icon {
         outline: 0;
         line-height: 1;
@@ -28,20 +14,8 @@
         position: relative;
 
         > svg {
-            fill: var(--kendo-icon-color);
-            transform: rotate(var(--kendo-icon-rotation));
+            fill: currentColor;
             flex: 1 1 auto;
-
-            [fill="none"] {
-                stroke: var(--kendo-icon-color);
-            }
-        }
-
-        &.k-svg-icon-outline,
-        &.k-svg-icon-duotone {
-            > svg [fill="none"] {
-                stroke-width: var(--kendo-icon-stroke-width);
-            }
         }
 
         // SVG Icon sizes
@@ -87,7 +61,9 @@
                 transform: none;
             }
 
-            --kendo-icon-rotation: #{$rotate};
+            > svg {
+                transform: rotate( #{$rotate} );
+            }
         }
     }
 


### PR DESCRIPTION
Reverts the following commits:
- 20839fb feat: add support for runtime icon size customization
- aee94c4 feat: add support for runtime rotation customization
- 17b312c feat: add support for runtime svg icon color customization
- 18113f9 feat: add support for runtime stroke-width customization